### PR TITLE
Remove unnecessarily permissive CORS configuration

### DIFF
--- a/nextlinegraphql/factory.py
+++ b/nextlinegraphql/factory.py
@@ -50,8 +50,7 @@ def create_app() -> Starlette:
         Middleware(
             CORSMiddleware,
             allow_origins=["*"],
-            allow_methods=["*"],
-            allow_headers=["*"],
+            allow_methods=['GET', 'POST', 'OPTIONS'],
         )
     ]
 

--- a/tests/app/test_cors.py
+++ b/tests/app/test_cors.py
@@ -34,7 +34,7 @@ async def test_preflight(client: TestClient) -> None:
     headers = {
         'ORIGIN': 'https://foo.example',
         'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'X-PINGOTHER, Content-Type',
+        'Access-Control-Request-Headers': 'Content-Type',
     }
 
     resp = await client.options('/', headers=headers)


### PR DESCRIPTION
- List `allow_methods` explicitly instead of the wildcard.
  - `OPTIONS` can be implicit but included for clarity.
- `allow_headers` is default to `[]`. `Content-Type` and a few others are always allowed. 
  - `X-PINGOTHER` is a fictional header that appeared in MDN doc.