### PR TITLE
Revert part of CORS configuration

### DIFF
--- a/nextlinegraphql/factory.py
+++ b/nextlinegraphql/factory.py
@@ -51,6 +51,7 @@ def create_app() -> Starlette:
             CORSMiddleware,
             allow_origins=["*"],
             allow_methods=['GET', 'POST', 'OPTIONS'],
+            allow_headers=['*'],
         )
     ]
 

--- a/tests/app/test_cors.py
+++ b/tests/app/test_cors.py
@@ -34,7 +34,7 @@ async def test_preflight(client: TestClient) -> None:
     headers = {
         'ORIGIN': 'https://foo.example',
         'Access-Control-Request-Method': 'POST',
-        'Access-Control-Request-Headers': 'Content-Type',
+        'Access-Control-Request-Headers': 'X-PINGOTHER, Content-Type',
     }
 
     resp = await client.options('/', headers=headers)


### PR DESCRIPTION
Allow any headres. This is probably necessary for user authentication in production.
I'll make both `allow_origins` and `allow_headers` configurable later.