### PR TITLE
Add origin access control for GraphQL Mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ _The plugin-based framework of a Python API server._
     - [Core package](#core-package)
     - [Plugin system](#plugin-system)
     - [Plugins](#plugins)
-      - [Internal plugins](#internal-plugins)
-      - [External plugins](#external-plugins)
     - [Utility](#utility)
   - [Frontend web app (TypeScript)](#frontend-web-app-typescript)
 - [How to run the Nextline backend API server](#how-to-run-the-nextline-backend-api-server)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ _The plugin-based framework of a Python API server._
     - [Core package](#core-package)
     - [Plugin system](#plugin-system)
     - [Plugins](#plugins)
+      - [Internal plugins](#internal-plugins)
+      - [External plugins](#external-plugins)
     - [Utility](#utility)
   - [Frontend web app (TypeScript)](#frontend-web-app-typescript)
 - [How to run the Nextline backend API server](#how-to-run-the-nextline-backend-api-server)
@@ -31,6 +33,7 @@ _The plugin-based framework of a Python API server._
 - [Configuration](#configuration)
   - [CORS](#cors)
   - [Logging](#logging)
+  - [`graphql` plugin](#graphql-plugin)
   - [`ctrl` plugin](#ctrl-plugin)
 - [Check out code for development](#check-out-code-for-development)
 
@@ -186,6 +189,16 @@ These CORS (Cross-Origin Resource Sharing) settings will be given to
 ### Logging
 
 See [`default.toml`](./nextlinegraphql/config/default.toml).
+
+### `graphql` plugin
+
+| Environment variable                       | Default value | Description                                                                                      |
+| ------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
+| `NEXTLINE_GRAPHQL__MUTATION_ALLOW_ORIGINS` | `[*]`         | A list of allowed origins for GraphQL Mutations. The default value (`"*"`) allows any origins.\* |
+
+- In addition to the CORS settings above, this setting provides further access control for
+  GraphQL Mutations. With this setting, you can allow only GraphQL Queries and Subscriptions from
+  certain origins while prohibiting Mutations.
 
 ### `ctrl` plugin
 

--- a/nextlinegraphql/factory.py
+++ b/nextlinegraphql/factory.py
@@ -28,12 +28,14 @@ class App(Starlette):
 
 
 def create_app_for_test(
+    extra_plugins: list[object] | None = None,
     enable_external_plugins: bool = False,
     enable_logging_configuration: bool = False,
     print_settings: bool = False,
 ) -> App:
     '''`create_app()` with default parameters suitable for tests.'''
     return create_app(
+        extra_plugins=extra_plugins,
         enable_external_plugins=enable_external_plugins,
         enable_logging_configuration=enable_logging_configuration,
         print_settings=print_settings,
@@ -41,6 +43,7 @@ def create_app_for_test(
 
 
 def create_app(
+    extra_plugins: list[object] | None = None,
     enable_external_plugins: bool = True,
     enable_logging_configuration: bool = True,
     print_settings: bool = True,
@@ -49,6 +52,8 @@ def create_app(
 
     Parameters
     ----------
+    extra_plugins
+        Additional plugins to load. (Used for tests.)
     enable_external_plugins
         Do not load external plugins if False. (Used for tests.)
     enable_logging_configuration
@@ -74,6 +79,7 @@ def create_app(
     '''
 
     hook, config = create_hook_and_config(
+        extra_plugins=extra_plugins,
         enable_external_plugins=enable_external_plugins,
         enable_logging_configuration=enable_logging_configuration,
         print_settings=print_settings,
@@ -84,11 +90,12 @@ def create_app(
 
 
 def create_hook_and_config(
+    extra_plugins: list[object] | None,
     enable_external_plugins: bool,
     enable_logging_configuration: bool,
     print_settings: bool,
 ) -> tuple[PluginManager, Dynaconf]:
-    hook = load_plugins(external=enable_external_plugins)
+    hook = load_plugins(external=enable_external_plugins, plugins=extra_plugins)
     config = load_settings(hook)
     if print_settings:
         print('Settings:', config.as_dict())

--- a/nextlinegraphql/factory.py
+++ b/nextlinegraphql/factory.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import Any
 
 from apluggy import PluginManager
-from dynaconf import LazySettings
+from dynaconf import Dynaconf
 from rich import print
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -82,7 +82,7 @@ def create_hook_and_config(
     enable_external_plugins: bool,
     enable_logging_configuration: bool,
     print_settings: bool
-) -> tuple[PluginManager, LazySettings]:
+) -> tuple[PluginManager, Dynaconf]:
     hook = load_plugins(external=enable_external_plugins)
     config = load_settings(hook)
     if print_settings:

--- a/nextlinegraphql/factory.py
+++ b/nextlinegraphql/factory.py
@@ -27,6 +27,19 @@ class App(Starlette):
         return self
 
 
+def create_app_for_test(
+    enable_external_plugins: bool = False,
+    enable_logging_configuration: bool = False,
+    print_settings: bool = False,
+) -> App:
+    '''`create_app()` with default parameters suitable for tests.'''
+    return create_app(
+        enable_external_plugins=enable_external_plugins,
+        enable_logging_configuration=enable_logging_configuration,
+        print_settings=print_settings,
+    )
+
+
 def create_app(
     enable_external_plugins: bool = True,
     enable_logging_configuration: bool = True,
@@ -99,6 +112,7 @@ def configure_logging(config: dict) -> None:
     # https://pypi.org/project/logging_tree/
     # import logging_tree
     # logging_tree.printout()
+
 
 def create_app_from(hook: PluginManager, config: Dynaconf) -> App:
     @contextlib.asynccontextmanager

--- a/nextlinegraphql/hook/__init__.py
+++ b/nextlinegraphql/hook/__init__.py
@@ -7,7 +7,9 @@ from nextlinegraphql.plugins import ctrl, dev, graphql
 from . import spec
 
 
-def load_plugins(external: bool = True) -> PluginManager:
+def load_plugins(
+    external: bool = True, plugins: list[object] | None = None
+) -> PluginManager:
     '''Return a pluggy PluginManager with the plugins registered'''
 
     pm = PluginManager(spec.PROJECT_NAME)
@@ -22,5 +24,9 @@ def load_plugins(external: bool = True) -> PluginManager:
 
     if external:
         pm.load_setuptools_entrypoints(spec.PROJECT_NAME)
+
+    if plugins:
+        for plugin in plugins:
+            pm.register(plugin)
 
     return pm

--- a/nextlinegraphql/plugins/graphql/cors_mutation.py
+++ b/nextlinegraphql/plugins/graphql/cors_mutation.py
@@ -1,0 +1,35 @@
+from collections.abc import AsyncIterator, Sequence
+
+from strawberry.exceptions import StrawberryGraphQLError
+from strawberry.extensions import SchemaExtension
+from strawberry.types.graphql import OperationType
+
+
+class CORSMutation(SchemaExtension):
+    def __init__(self, allow_origins: Sequence[str]):
+        self._allow_origins = allow_origins
+
+    async def on_execute(self) -> AsyncIterator[None]:
+        if not self._is_origin_allowed():
+            raise StrawberryGraphQLError('GraphQL Mutations not allowed')
+
+        yield
+
+    def _is_origin_allowed(self) -> bool:
+        if '*' in self._allow_origins:
+            return True
+
+        op_type = self.execution_context.operation_type
+        if op_type is not OperationType.MUTATION:
+            return True
+
+        request = self.execution_context.context.get('request')
+        origin = request.headers.get('origin')
+        if origin is None:
+            #  Same origin or non-browser request
+            return True
+
+        if origin in self._allow_origins:
+            return True
+
+        return False

--- a/nextlinegraphql/plugins/graphql/default.toml
+++ b/nextlinegraphql/plugins/graphql/default.toml
@@ -1,0 +1,10 @@
+# Default settings
+#
+# Syntax can be learned from Dynaconf examples 
+# https://github.com/rochacbruno/learndynaconf/tree/main/configs
+
+[graphql]
+# The following settings are commented out because the lists `['*']` would be
+# merged with the local settings rather than overridden. The default values are
+# instead provided with `Validate()` in the code.
+# mutation_allow_origins = ["*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ timeout = 60
 addopts = "--doctest-modules"
 # doctest_optionflags = ["ELLIPSIS", "NORMALIZE_WHITESPACE",]
 doctest_optionflags = ["ELLIPSIS"]
+filterwarnings = ["ignore::hypothesis.errors.NonInteractiveExampleWarning"]
 log_cli = false
 log_cli_level = "INFO"
 

--- a/tests/app/cors/strategies.py
+++ b/tests/app/cors/strategies.py
@@ -3,6 +3,8 @@ from string import ascii_lowercase
 from hypothesis import provisional
 from hypothesis import strategies as st
 
+from nextline_test_utils.strategies import st_none_or
+
 # Headers always allowed by CORS.
 # https://www.starlette.io/middleware/#corsmiddleware
 ALWAYS_ALLOWED_HEADERS = (
@@ -68,3 +70,17 @@ def st_methods() -> st.SearchStrategy[str]:
 
     '''
     return st.sampled_from(ALL_METHODS)
+
+
+def st_allow_origins() -> st.SearchStrategy[list[str] | None]:
+    '''None, ['*'], or a list of origins.'''
+    return st.one_of(st.none(), st.just(['*']), st.lists(st_origins()))
+
+
+def st_header_origin(allow_origins: list[str] | None) -> st.SearchStrategy[str | None]:
+    '''None or an origin that may be allowed.'''
+    return st_none_or(
+        st_origins()
+        if not allow_origins or '*' in allow_origins
+        else st.one_of(st.sampled_from(allow_origins), st_origins())
+    )

--- a/tests/app/cors/strategies.py
+++ b/tests/app/cors/strategies.py
@@ -73,12 +73,18 @@ def st_methods() -> st.SearchStrategy[str]:
 
 
 def st_allow_origins() -> st.SearchStrategy[list[str] | None]:
-    '''None, ['*'], or a list of origins.'''
+    '''A strategy for allowed CORS origins.
+
+    None, ['*'], or a list of origins.
+    '''
     return st.one_of(st.none(), st.just(['*']), st.lists(st_origins()))
 
 
 def st_header_origin(allow_origins: list[str] | None) -> st.SearchStrategy[str | None]:
-    '''None or an origin that may be allowed.'''
+    '''A strategy for an HTTP request header 'Origin'.
+
+    None or an origin that may be allowed.
+    '''
     return st_none_or(
         st_origins()
         if not allow_origins or '*' in allow_origins

--- a/tests/app/cors/strategies.py
+++ b/tests/app/cors/strategies.py
@@ -81,7 +81,7 @@ def st_allow_origins() -> st.SearchStrategy[list[str]]:
 def st_header_origin(allow_origins: list[str] | None) -> st.SearchStrategy[str]:
     '''A strategy for an HTTP request header 'Origin'.
 
-    None or an origin that may be allowed.
+    An origin that may be allowed.
     '''
     return (
         st_origins()

--- a/tests/app/cors/strategies.py
+++ b/tests/app/cors/strategies.py
@@ -3,25 +3,7 @@ from string import ascii_lowercase
 from hypothesis import provisional
 from hypothesis import strategies as st
 
-
-def st_origins() -> st.SearchStrategy[str]:
-    '''A strategy for origins.
-
-    E.g.  `https://example.com:8080`
-    '''
-
-    # `schemes` and `ports` copied from `provisional.urls()`
-    schemes = st.sampled_from(['http', 'https'])
-    ports = st.integers(min_value=1, max_value=2**16 - 1).map(':{}'.format)
-
-    return st.builds(
-        '{}://{}{}'.format,
-        schemes,
-        provisional.domains(),
-        st.just('') | ports,
-    )
-
-
+# Headers always allowed by CORS.
 # https://www.starlette.io/middleware/#corsmiddleware
 ALWAYS_ALLOWED_HEADERS = (
     'Accept',
@@ -30,19 +12,39 @@ ALWAYS_ALLOWED_HEADERS = (
     'Content-Type',
 )
 
-# Methods allowed when `allow_methods` is set to `['*']`
+# HTTP methods allowed when `allow_methods` is set to `['*']`.
 ALL_METHODS = ('DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT')
 
-# Specified in `factory.py`
+# HTTP methods hard-coded to be allowed in `factory.py`.
 ALLOWED_METHODS = ('GET', 'POST', 'OPTIONS')
+
+
+def st_origins() -> st.SearchStrategy[str]:
+    '''A strategy for HTTP origins.
+
+    The HTTP origin consists of scheme, host, and optional port.
+    E.g., `https://example.com:8080`
+
+    '''
+
+    # `schemes` and `ports` copied from `provisional.urls()`
+    st_schemes = st.sampled_from(['http', 'https'])
+    st_ports = st.integers(min_value=1, max_value=2**16 - 1).map(':{}'.format)
+
+    return st.builds(
+        '{}://{}{}'.format,
+        st_schemes,
+        provisional.domains(),
+        st.just('') | st_ports,
+    )
 
 
 def st_headers() -> st.SearchStrategy[str]:
     '''A strategy for HTTP headers.
 
     One of the always allowed headers or a random header.
-
     E.g., `Content-Type`, Nykbjacgeh-Kgvudhdbup-Nj`
+
     '''
     return st.one_of(
         st.sampled_from(ALWAYS_ALLOWED_HEADERS),
@@ -62,7 +64,7 @@ def st_methods() -> st.SearchStrategy[str]:
     '''A strategy for HTTP methods.
 
     One of the methods either allowed or not allowed by the CORS.
-
     E.g., `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`
+
     '''
     return st.sampled_from(ALL_METHODS)

--- a/tests/app/cors/strategies.py
+++ b/tests/app/cors/strategies.py
@@ -72,20 +72,20 @@ def st_methods() -> st.SearchStrategy[str]:
     return st.sampled_from(ALL_METHODS)
 
 
-def st_allow_origins() -> st.SearchStrategy[list[str] | None]:
+def st_allow_origins() -> st.SearchStrategy[list[str]]:
     '''A strategy for allowed CORS origins.
 
-    None, ['*'], or a list of origins.
+    ['*'], or a list of origins.
     '''
-    return st.one_of(st.none(), st.just(['*']), st.lists(st_origins()))
+    return st.one_of(st.just(['*']), st.lists(st_origins()))
 
 
-def st_header_origin(allow_origins: list[str] | None) -> st.SearchStrategy[str | None]:
+def st_header_origin(allow_origins: list[str] | None) -> st.SearchStrategy[str]:
     '''A strategy for an HTTP request header 'Origin'.
 
     None or an origin that may be allowed.
     '''
-    return st_none_or(
+    return (
         st_origins()
         if not allow_origins or '*' in allow_origins
         else st.one_of(st.sampled_from(allow_origins), st_origins())

--- a/tests/app/cors/strategies.py
+++ b/tests/app/cors/strategies.py
@@ -3,8 +3,6 @@ from string import ascii_lowercase
 from hypothesis import provisional
 from hypothesis import strategies as st
 
-from nextline_test_utils.strategies import st_none_or
-
 # Headers always allowed by CORS.
 # https://www.starlette.io/middleware/#corsmiddleware
 ALWAYS_ALLOWED_HEADERS = (

--- a/tests/app/cors/test_get.py
+++ b/tests/app/cors/test_get.py
@@ -3,7 +3,7 @@ from hypothesis import strategies as st
 from pytest import MonkeyPatch
 
 from nextline_test_utils.strategies import st_none_or
-from nextlinegraphql import create_app
+from nextlinegraphql.factory import create_app_for_test
 from nextlinegraphql.plugins.graphql.test import TestClient
 
 from .strategies import st_allow_origins, st_header_origin
@@ -39,11 +39,7 @@ async def test_property(data: st.DataObject, monkeypatch: MonkeyPatch) -> None:
         if allow_origins is not None:
             m.setenv('NEXTLINE_CORS__ALLOW_ORIGINS', repr(allow_origins))
 
-        app = create_app(
-            enable_external_plugins=False,
-            enable_logging_configuration=False,
-            print_settings=False,
-        )
+        app = create_app_for_test()
         async with TestClient(app) as client:
             #
             resp = await client.get('/', headers=headers)

--- a/tests/app/cors/test_get.py
+++ b/tests/app/cors/test_get.py
@@ -2,6 +2,7 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from pytest import MonkeyPatch
 
+from nextline_test_utils.strategies import st_none_or
 from nextlinegraphql import create_app
 from nextlinegraphql.plugins.graphql.test import TestClient
 
@@ -22,11 +23,11 @@ async def test_property(data: st.DataObject, monkeypatch: MonkeyPatch) -> None:
 
     ## None, ['*'], or a list of origins
     ## If None, no environment variable is set, default to ['*']
-    allow_origins = data.draw(st_allow_origins())
+    allow_origins = data.draw(st_none_or(st_allow_origins()))
 
     ## None or an origin that may be allowed
     ## If None, the request header does not include 'Origin'
-    header_origin = data.draw(st_header_origin(allow_origins))
+    header_origin = data.draw(st_none_or(st_header_origin(allow_origins)))
 
     # Build the request header
     headers = {'accept': 'text/html'}

--- a/tests/app/cors/test_get.py
+++ b/tests/app/cors/test_get.py
@@ -2,11 +2,10 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from pytest import MonkeyPatch
 
-from nextline_test_utils.strategies import st_none_or
 from nextlinegraphql import create_app
 from nextlinegraphql.plugins.graphql.test import TestClient
 
-from .strategies import st_origins
+from .strategies import st_allow_origins, st_header_origin
 
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
@@ -60,17 +59,3 @@ async def test_property(data: st.DataObject, monkeypatch: MonkeyPatch) -> None:
                 assert header_origin == resp.headers['access-control-allow-origin']
             else:
                 'access-control-allow-origin' not in resp.headers
-
-
-def st_allow_origins() -> st.SearchStrategy[list[str] | None]:
-    '''None, ['*'], or a list of origins.'''
-    return st.one_of(st.none(), st.just(['*']), st.lists(st_origins()))
-
-
-def st_header_origin(allow_origins: list[str] | None) -> st.SearchStrategy[str | None]:
-    '''None or an origin that may be allowed.'''
-    return st_none_or(
-        st_origins()
-        if not allow_origins or '*' in allow_origins
-        else st.one_of(st.sampled_from(allow_origins), st_origins())
-    )

--- a/tests/app/cors/test_preflight.py
+++ b/tests/app/cors/test_preflight.py
@@ -9,9 +9,10 @@ from nextlinegraphql.plugins.graphql.test import TestClient
 from .strategies import (
     ALLOWED_METHODS,
     ALWAYS_ALLOWED_HEADERS,
+    st_allow_origins,
+    st_header_origin,
     st_headers,
     st_methods,
-    st_origins,
 )
 
 
@@ -30,10 +31,7 @@ async def test_property(data: st.DataObject, monkeypatch: MonkeyPatch) -> None:
     ## allow_origins: an env var NEXTLINE_CORS__ALLOW_ORIGINS
     ## None, ['*'], or a list of origins
     ## If None, the environment variable is not set, default to ['*']
-    allow_origins = data.draw(
-        st.one_of(st.none(), st.just(['*']), st.lists(st_origins())),
-        label='allow_origins',
-    )
+    allow_origins = data.draw(st_none_or(st_allow_origins()), label='allow_origins')
 
     ## allow_headers: an env var NEXTLINE_CORS__ALLOW_HEADERS
     ## None, ['*'], or a list of headers
@@ -54,12 +52,7 @@ async def test_property(data: st.DataObject, monkeypatch: MonkeyPatch) -> None:
     allow_credentials = data.draw(st_allow_credentials, label='allow_credentials')
 
     ## header_origin: an HTTP request header 'Origin'
-    header_origin = data.draw(
-        st_origins()
-        if not allow_origins or '*' in allow_origins
-        else st.one_of(st_origins(), st.sampled_from(allow_origins)),
-        label='header_origin',
-    )
+    header_origin = data.draw(st_header_origin(allow_origins), label='header_origin')
 
     ## header_request_method: an HTTP request header 'Access-Control-Request-Method'
     header_request_method = data.draw(st_methods(), label='header_request_method')

--- a/tests/app/cors/test_preflight.py
+++ b/tests/app/cors/test_preflight.py
@@ -3,7 +3,7 @@ from hypothesis import strategies as st
 from pytest import MonkeyPatch
 
 from nextline_test_utils.strategies import st_none_or
-from nextlinegraphql import create_app
+from nextlinegraphql.factory import create_app_for_test
 from nextlinegraphql.plugins.graphql.test import TestClient
 
 from .strategies import (
@@ -90,11 +90,7 @@ async def test_property(data: st.DataObject, monkeypatch: MonkeyPatch) -> None:
         if allow_credentials is not None:
             m.setenv('NEXTLINE_CORS__ALLOW_CREDENTIALS', str(allow_credentials).lower())
 
-        app = create_app(
-            enable_external_plugins=False,
-            enable_logging_configuration=False,
-            print_settings=False,
-        )
+        app = create_app_for_test()
         async with TestClient(app) as client:
             #
             resp = await client.options('/', headers=headers)

--- a/tests/app/cors/test_strategies.py
+++ b/tests/app/cors/test_strategies.py
@@ -4,6 +4,8 @@ from urllib.parse import urlparse
 from hypothesis import given
 from hypothesis import strategies as st
 
+from nextline_test_utils.strategies import st_none_or
+
 from .strategies import (
     ALL_METHODS,
     st_allow_origins,
@@ -41,7 +43,7 @@ def test_allow_origins(allow_origins: list[str]) -> None:
 
 @given(data=st.data())
 def test_header_origin(data: st.DataObject) -> None:
-    allow_origins = data.draw(st_allow_origins())
+    allow_origins = data.draw(st_none_or(st_allow_origins()))
     header_origin = data.draw(st_header_origin(allow_origins))
 
     if allow_origins and '*' not in allow_origins:

--- a/tests/app/cors/test_strategies.py
+++ b/tests/app/cors/test_strategies.py
@@ -1,0 +1,23 @@
+import re
+from urllib.parse import urlparse
+
+from hypothesis import given
+
+from .strategies import ALL_METHODS, st_headers, st_methods, st_origins
+
+
+@given(origin=st_origins())
+def test_origin(origin: str) -> None:
+    parsed = urlparse(origin)
+    assert f'{parsed.scheme}://{parsed.netloc}' == origin
+
+
+@given(header=st_headers())
+def test_header(header: str) -> None:
+    pattern = r'^[A-Z][a-z]*(?:-[A-Z][a-z]*)*$'
+    assert re.match(pattern, header)
+
+
+@given(method=st_methods())
+def test_method(method: str) -> None:
+    assert method in ALL_METHODS

--- a/tests/app/cors/test_strategies.py
+++ b/tests/app/cors/test_strategies.py
@@ -34,7 +34,6 @@ def test_method(method: str) -> None:
 
 @given(allow_origins=st_allow_origins())
 def test_allow_origins(allow_origins: list[str]) -> None:
-
     if '*' in allow_origins:
         return
 

--- a/tests/app/cors/test_strategies.py
+++ b/tests/app/cors/test_strategies.py
@@ -2,14 +2,21 @@ import re
 from urllib.parse import urlparse
 
 from hypothesis import given
+from hypothesis import strategies as st
 
-from .strategies import ALL_METHODS, st_headers, st_methods, st_origins
+from .strategies import (
+    ALL_METHODS,
+    st_allow_origins,
+    st_header_origin,
+    st_headers,
+    st_methods,
+    st_origins,
+)
 
 
 @given(origin=st_origins())
 def test_origin(origin: str) -> None:
-    parsed = urlparse(origin)
-    assert f'{parsed.scheme}://{parsed.netloc}' == origin
+    assert _is_valid_origin(origin)
 
 
 @given(header=st_headers())
@@ -21,3 +28,34 @@ def test_header(header: str) -> None:
 @given(method=st_methods())
 def test_method(method: str) -> None:
     assert method in ALL_METHODS
+
+
+@given(allow_origins=st_allow_origins())
+def test_allow_origins(allow_origins: list[str] | None) -> None:
+    if allow_origins is None:
+        return
+
+    if '*' in allow_origins:
+        return
+
+    assert all(_is_valid_origin(o) for o in allow_origins)
+
+
+@given(data=st.data())
+def test_header_origin(data: st.DataObject) -> None:
+    allow_origins = data.draw(st_allow_origins())
+    header_origin = data.draw(st_header_origin(allow_origins))
+
+    if header_origin is None:
+        return
+
+    if allow_origins and '*' not in allow_origins:
+        if header_origin in allow_origins:
+            return
+
+    assert _is_valid_origin(header_origin)
+
+
+def _is_valid_origin(origin: str) -> bool:
+    parsed = urlparse(origin)
+    return f'{parsed.scheme}://{parsed.netloc}' == origin

--- a/tests/app/cors/test_strategies.py
+++ b/tests/app/cors/test_strategies.py
@@ -31,9 +31,7 @@ def test_method(method: str) -> None:
 
 
 @given(allow_origins=st_allow_origins())
-def test_allow_origins(allow_origins: list[str] | None) -> None:
-    if allow_origins is None:
-        return
+def test_allow_origins(allow_origins: list[str]) -> None:
 
     if '*' in allow_origins:
         return
@@ -45,9 +43,6 @@ def test_allow_origins(allow_origins: list[str] | None) -> None:
 def test_header_origin(data: st.DataObject) -> None:
     allow_origins = data.draw(st_allow_origins())
     header_origin = data.draw(st_header_origin(allow_origins))
-
-    if header_origin is None:
-        return
 
     if allow_origins and '*' not in allow_origins:
         if header_origin in allow_origins:

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,5 +1,6 @@
 from nextlinegraphql import create_app
 from nextlinegraphql.factory import create_app_for_test
+from nextlinegraphql.hook import spec
 
 
 def test_app() -> None:
@@ -16,3 +17,13 @@ def test_create_app_for_test() -> None:
     app = create_app_for_test()
     assert app.hook is not None
     assert app.config is not None
+
+
+class MockPlugin:
+    pass
+
+
+def test_extra_plugins() -> None:
+    plugin = MockPlugin()
+    app = create_app_for_test(extra_plugins=[plugin])
+    assert plugin in app.hook.get_plugins()

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,4 +1,5 @@
 from nextlinegraphql import create_app
+from nextlinegraphql.factory import create_app_for_test
 
 
 def test_app() -> None:
@@ -7,5 +8,11 @@ def test_app() -> None:
         enable_logging_configuration=False,
         print_settings=False,
     )
+    assert app.hook is not None
+    assert app.config is not None
+
+
+def test_create_app_for_test() -> None:
+    app = create_app_for_test()
     assert app.hook is not None
     assert app.config is not None

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,0 +1,11 @@
+from nextlinegraphql import create_app
+
+
+def test_app() -> None:
+    app = create_app(
+        enable_external_plugins=False,
+        enable_logging_configuration=False,
+        print_settings=False,
+    )
+    assert app.hook is not None
+    assert app.config is not None

--- a/tests/plugins/ctrl/schema/examples/test_async_asgi_testclient.py
+++ b/tests/plugins/ctrl/schema/examples/test_async_asgi_testclient.py
@@ -1,4 +1,4 @@
-from nextlinegraphql import create_app
+from nextlinegraphql.factory import create_app_for_test
 from nextlinegraphql.plugins.graphql.test import TestClient
 
 
@@ -15,7 +15,7 @@ async def test_query() -> None:
         'Content-Type:': 'application/json',
     }
 
-    async with TestClient(create_app(enable_external_plugins=False)) as client:
+    async with TestClient(create_app_for_test()) as client:
         resp = await client.post('/', json=data, headers=headers)
         assert resp.status_code == 200
         expect = {'data': {'ctrl': {'hello': 'Hello, Mozilla/5.0!'}}}
@@ -40,7 +40,7 @@ async def test_subscription() -> None:
         },
     }
 
-    async with TestClient(create_app(enable_external_plugins=False)) as client:
+    async with TestClient(create_app_for_test()) as client:
         async with client.websocket_connect('/') as ws:
             await ws.send_json(data)
 

--- a/tests/plugins/ctrl/test_config.py
+++ b/tests/plugins/ctrl/test_config.py
@@ -3,7 +3,7 @@ from hypothesis import strategies as st
 from pytest import MonkeyPatch
 
 from nextline_test_utils.strategies import st_none_or
-from nextlinegraphql.factory import create_hook_and_config
+from nextlinegraphql.factory import create_app_for_test
 from nextlinegraphql.plugins.ctrl import Plugin
 
 DEFAULT_TRACE_MODULES = False
@@ -11,11 +11,9 @@ DEFAULT_TRACE_THREADS = False
 
 
 def test_default() -> None:
-    hook, config = create_hook_and_config(
-        enable_external_plugins=False,
-        enable_logging_configuration=False,
-        print_settings=False,
-    )
+    app = create_app_for_test()
+    hook = app.hook
+    config = app.config
     assert config.ctrl.trace_modules is DEFAULT_TRACE_MODULES
     assert config.ctrl.trace_threads is DEFAULT_TRACE_THREADS
 
@@ -37,11 +35,9 @@ def test_property(
         if trace_threads is not None:
             m.setenv('NEXTLINE_CTRL__TRACE_THREADS', str(trace_threads).lower())
 
-        hook, config = create_hook_and_config(
-            enable_external_plugins=False,
-            enable_logging_configuration=True,
-            print_settings=True,
-        )
+        app = create_app_for_test()
+        hook = app.hook
+        config = app.config
 
         expected_trace_modules = (
             trace_modules if trace_modules is not None else DEFAULT_TRACE_MODULES

--- a/tests/plugins/ctrl/test_config.py
+++ b/tests/plugins/ctrl/test_config.py
@@ -29,7 +29,6 @@ def test_property(
     trace_modules: bool | None, trace_threads: bool | None, monkeypatch: MonkeyPatch
 ) -> None:
     with monkeypatch.context() as m:
-        pass
         if trace_modules is not None:
             m.setenv('NEXTLINE_CTRL__TRACE_MODULES', str(trace_modules).lower())
         if trace_threads is not None:

--- a/tests/plugins/ctrl/test_plugin.py
+++ b/tests/plugins/ctrl/test_plugin.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from nextlinegraphql import create_app
+from nextlinegraphql.factory import create_app_for_test
 from nextlinegraphql.plugins.ctrl.graphql import (
     MUTATE_RUN_AND_CONTINUE,
     QUERY_STATE,
@@ -37,11 +37,7 @@ async def _subscribe_state(client: TestClient) -> list[str]:
 
 @pytest.fixture
 async def client() -> AsyncIterator[TestClient]:
-    app = create_app(
-        enable_external_plugins=False,
-        enable_logging_configuration=False,
-        print_settings=False,
-    )
+    app = create_app_for_test()
     async with TestClient(app) as y:
         await asyncio.sleep(0)
         yield y

--- a/tests/plugins/graphql/conftest.py
+++ b/tests/plugins/graphql/conftest.py
@@ -3,17 +3,13 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from nextlinegraphql import create_app
+from nextlinegraphql.factory import create_app_for_test
 from nextlinegraphql.plugins.graphql.test import TestClient
 
 
 @pytest.fixture
 async def client() -> AsyncIterator[TestClient]:
-    app = create_app(
-        enable_external_plugins=False,
-        enable_logging_configuration=False,
-        print_settings=False,
-    )
+    app = create_app_for_test()
     async with TestClient(app) as y:
         await asyncio.sleep(0)
         yield y

--- a/tests/plugins/graphql/test_config.py
+++ b/tests/plugins/graphql/test_config.py
@@ -1,0 +1,32 @@
+from hypothesis import HealthCheck, given, settings
+from pytest import MonkeyPatch
+
+from nextline_test_utils.strategies import st_none_or
+from nextlinegraphql.factory import create_app_for_test
+from nextlinegraphql.plugins.graphql import Plugin
+from tests.app.cors.strategies import st_allow_origins
+
+
+def test_default() -> None:
+    app = create_app_for_test()
+    hook = app.hook
+    config = app.config
+    assert config.graphql.mutation_allow_origins == ['*']
+
+    plugin = hook.get_plugin('graphql')
+    assert isinstance(plugin, Plugin)
+    assert plugin._settings is config
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(allow_origins=st_none_or(st_allow_origins()))
+def test_property(allow_origins: list[str] | None, monkeypatch: MonkeyPatch) -> None:
+    with monkeypatch.context() as m:
+        if allow_origins is not None:
+            m.setenv('NEXTLINE_GRAPHQL__MUTATION_ALLOW_ORIGINS', repr(allow_origins))
+
+        app = create_app_for_test()
+        config = app.config
+
+        expected = allow_origins if allow_origins is not None else ['*']
+        assert config.graphql.mutation_allow_origins == expected

--- a/tests/plugins/graphql/test_cors_mutation.py
+++ b/tests/plugins/graphql/test_cors_mutation.py
@@ -1,0 +1,140 @@
+import strawberry
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pytest import MonkeyPatch
+
+from nextline_test_utils.strategies import st_none_or
+from nextlinegraphql.factory import create_app_for_test
+from nextlinegraphql.hook import spec
+from nextlinegraphql.plugins.graphql.test import TestClient
+from nextlinegraphql.plugins.graphql.test.funcs import PostRequest
+from tests.app.cors.strategies import st_allow_origins, st_header_origin
+
+
+@strawberry.type
+class QueryMock:
+    @strawberry.field
+    def foo(self) -> str:
+        return 'bar'
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def mock(self) -> QueryMock:
+        return QueryMock()
+
+
+@strawberry.type
+class MutationMock:
+    @strawberry.mutation
+    def baz(self) -> str:
+        return 'qux'
+
+
+@strawberry.type
+class Mutation:
+    @strawberry.field
+    def mock(self) -> MutationMock:
+        return MutationMock()
+
+
+QUERY_FOO = '''
+query {
+  mock {
+    foo
+  }
+}
+'''
+
+MUTATE_BAZ = '''
+mutation {
+  mock {
+    baz
+  }
+}
+'''
+
+
+class MockPlugin:
+    @spec.hookimpl
+    def schema(self) -> tuple[type, type | None, type | None]:
+        return (Query, Mutation, None)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(data=st.data())
+async def test_property(data: st.DataObject, monkeypatch: MonkeyPatch) -> None:
+    '''Test CORS configurations.
+
+    Useful links about CORS
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
+    https://gist.github.com/FND/204ba41bf6ae485965ef
+
+    '''
+    # Draw from the strategies
+
+    ## None, ['*'], or a list of origins
+    ## If None, no environment variable is set, default to ['*']
+    allow_origins = data.draw(st_none_or(st_allow_origins()))
+
+    ## None, ['*'], or a list of origins
+    ## If None, no environment variable is set, default to ['*']
+    mutation_allow_origins = allow_origins if allow_origins is not None else ['*']
+
+    ## None or an origin that may be allowed
+    ## If None, the request header does not include 'Origin'
+    header_origin = data.draw(st_none_or(st_header_origin(allow_origins)))
+
+    # Build the request header
+    headers = {'Content-Type:': 'application/json'}
+    if header_origin is not None:
+        headers['origin'] = header_origin
+
+    with monkeypatch.context() as m:
+        # Configure with environment variables
+        if allow_origins is not None:
+            m.setenv('NEXTLINE_CORS__ALLOW_ORIGINS', repr(allow_origins))
+
+        if mutation_allow_origins is not None:
+            m.setenv(
+                'NEXTLINE_GRAPHQL__MUTATION_ALLOW_ORIGINS', repr(mutation_allow_origins)
+            )
+
+        mock_plugin = MockPlugin()
+        app = create_app_for_test(extra_plugins=[mock_plugin])
+        async with TestClient(app) as client:
+            QUERY = data.draw(st.sampled_from([QUERY_FOO, MUTATE_BAZ]))
+            request = PostRequest(query=QUERY)
+            resp = await client.post('/', json=request, headers=headers)
+
+            # Successfully processed regardless of whether the origin is allowed
+            assert resp.status_code == 200
+
+            # Assert 'Access-Control-Allow-Origin'
+            if header_origin is None:
+                'access-control-allow-origin' not in resp.headers
+            elif allow_origins == ['*'] or allow_origins is None:
+                assert '*' == resp.headers['access-control-allow-origin']
+            elif header_origin in allow_origins:
+                assert header_origin == resp.headers['access-control-allow-origin']
+            else:
+                'access-control-allow-origin' not in resp.headers
+
+            # Assert the response content
+            if QUERY == QUERY_FOO:
+                assert resp.json() == {'data': {'mock': {'foo': 'bar'}}}
+            elif QUERY == MUTATE_BAZ:
+                if header_origin is None:
+                    assert resp.json() == {'data': {'mock': {'baz': 'qux'}}}
+                elif (
+                    mutation_allow_origins == ['*']
+                    or mutation_allow_origins is None
+                    or header_origin in mutation_allow_origins
+                ):
+                    assert resp.json() == {'data': {'mock': {'baz': 'qux'}}}
+                else:
+                    assert resp.json() == {
+                        'data': None,
+                        'errors': [{'message': 'GraphQL Mutations not allowed'}],
+                    }


### PR DESCRIPTION
Add a new setting `NEXTLINE_GRAPHQL__MUTATION_ALLOW_ORIGINS`, a list of allowed origins for GraphQL Mutations.
In addition to the CORS settings, this setting provides further access control for GraphQL Mutations. With this setting, you can allow only GraphQL Queries and Subscriptions from certain origins while prohibiting Mutations.